### PR TITLE
ForkedLens added: parallel composition of sub-lenses

### DIFF
--- a/lenses/baselens.py
+++ b/lenses/baselens.py
@@ -169,6 +169,29 @@ class ComposedLens(LensLike):
         return ' & '.join(str(l) for l in self.lenses)
 
 
+class ForkedLens(LensLike):
+    '''A lenses representing the parallel composition of several sub-lenses.
+
+        >>> from lenses import lens
+        >>> lens().fork_(lens()[0], lens()[2])
+        Lens(None, (Lens(None, GetitemLens(0))) | (Lens(None, GetitemLens(2))))
+        >>> lens([[0, 0], 0, 0]).fork_(lens()[0][1], lens()[2]).set(1)
+        [[0, 1], 0, 1]
+    '''
+
+    def __init__(self, *lenses):
+        self.lenses = lenses
+
+    def func(self, f, state):
+        for lens in self.lenses:
+            state = lens._underlying_lens().func(f, state).unwrap()
+
+        return Identity(state)
+
+    def __repr__(self):
+        return ' | '.join('({})'.format(l) for l in self.lenses)
+
+
 class GetterSetterLens(LensLike):
     '''Turns a pair of getter and setter functions into a van
     Laarhoven lens. A getter function is one that takes a state and

--- a/lenses/lens.py
+++ b/lenses/lens.py
@@ -8,6 +8,7 @@ lens_methods = [
     ('error_', baselens.ErrorLens),
     ('each_', baselens.EachLens),
     ('filter_', baselens.FilteringLens),
+    ('fork_', baselens.ForkedLens),
     ('get_', baselens.GetitemOrElseLens),
     ('getattr_', baselens.GetattrLens),
     ('getzoomattr_', baselens.GetZoomAttrLens),


### PR DESCRIPTION
I have added a new LensLike class: ForkedLens. It is similar to the ComposedLens but the composition is parallel from the point, where the lens starts. Maybe some more optimization should be added, but I have not study the internals of your library so deeply that I could optimize it.