### PR TITLE
Don't install typing backport library on python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     ],
     keywords='lens lenses immutable functional optics',
     packages=setuptools.find_packages(exclude=['tests']),
-    install_requires=['singledispatch', 'typing'],
+    install_requires=['singledispatch', 'typing;python_version<"3"'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'coverage', 'hypothesis', 'mypy'],
 )


### PR DESCRIPTION
On python3, `typing` is part of the standard library. This change will make it only be listed as a requirement on python2