### PR TITLE
Specify maximum python versions for dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ except IOError:
 
 dependencies = [
     'dataclasses;python_version=="3.6"',
-    "singledispatch",
-    "typing",
 ]
 
 documentation_dependencies = [


### PR DESCRIPTION
The dependencies 'typing' and 'singledispatch' are only required
for Python < 3.5

I had trouble building an venv with Python 3.8, it complained about those packages, so I followed the instructions at https://pypi.org/project/typing/