### PR TITLE
Fix error in Item lens when deleting key that does not exist

### DIFF
--- a/lenses/optics/true_lenses.py
+++ b/lenses/optics/true_lenses.py
@@ -159,10 +159,16 @@ class ItemLens(Lens):
     def setter(self, state, focus):
         data = state.copy()
         if focus is None:
-            del data[self.key]
+            try:
+                del data[self.key]
+            except KeyError:
+                pass
             return data
         if focus[0] != self.key:
-            del data[self.key]
+            try:
+                del data[self.key]
+            except KeyError:
+                pass
         data[focus[0]] = focus[1]
         return data
 

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -326,6 +326,12 @@ def test_ItemLens_set():
     assert itemlens.set(data, (2, "everyone")) == {0: "hello", 2: "everyone"}
 
 
+def test_ItemLens_unset_nonexistent():
+    data = {0: "hello"}
+    itemlens = b.ItemLens(1)
+    assert itemlens.set(data, None) == data
+
+
 def test_ItemByValueLens_view():
     data = {"hello": 0, "world": 1}
     assert b.ItemByValueLens(1).view(data) == ("world", 1)


### PR DESCRIPTION
Hello! Thank you for this library. I discovered it today and both the lib and its documentation are a real treat. I used it to transform a deep json payload in a mitmproxy script, and it was perfect for that.

I however encountered a bug in the Item lens in a use case I had. It was similar to this example: a traversal over values of existing "foo" entries in a list of dictionaries. I figured I would contribute a test case and a fix.

With this PR, this now returns true:
```py
from lenses import lens

foo_values = lens.Each().Item("foo").Filter(bool)[1]
("hello " + foo_values)([{}, {"foo": "world"}]) == [{}, {'foo': 'hello world'}]
```

In current version 1.1.0, it crashes with `KeyError: 'foo'` in the `setter` method of `ItemLens`.

Note that this is not the same traversal as `lens.Each().Get("foo").Filter(bool)`, whose use instead results in `[[{'foo': None}, {'foo': 'hello world'}]` (which, incidentally, had me a bit confused at first).